### PR TITLE
make icdiff compatible with python3 (as well as python2)

### DIFF
--- a/icdiff
+++ b/icdiff
@@ -62,9 +62,9 @@ class ConsoleDiff(object):
 
         if wrapcolumn is None:
             if not line_numbers:
-                wrapcolumn = self.cols/2-2
+                wrapcolumn = self.cols//2-2
             else:
-                wrapcolumn = self.cols/2-10
+                wrapcolumn = self.cols//2-10
 
         self._wrapcolumn = wrapcolumn
         self._linejunk = linejunk
@@ -234,7 +234,7 @@ class ConsoleDiff(object):
                     l += 1
             prev = c
 
-        #print "len '%s' is %d." % (s, l)
+        #print("len '%s' is %d." % (s, l))
         return l
 
 
@@ -247,7 +247,7 @@ class ConsoleDiff(object):
     def _lpad(self, s, field_width):
         target = s + self._pad(s, field_width)
         #if self._real_len(target) != field_width:
-        #    print "Warning: bad line %r is not of length %d" % (target, field_width)
+        #    print("Warning: bad line %r is not of length %d" % (target, field_width))
         return target
 
     def _convert_flags(self,fromlist,tolist,flaglist,context,numlines):
@@ -360,7 +360,7 @@ class ConsoleDiff(object):
         for sides in s:
             line = []
             for side in sides:
-                line.append(self._lpad(side, self.cols/2-1))
+                line.append(self._lpad(side, self.cols//2-1))
             table_lines.append(" ".join(line))
 
         table_line_string="\n".join(table_lines)
@@ -468,7 +468,7 @@ if __name__ == "__main__":
     (options, args) = parser.parse_args()
 
     if options.version:
-        print "icdiff version 0.1"
+        print("icdiff version 0.1")
         sys.exit()
 
     if len(args) != 2:
@@ -503,8 +503,8 @@ if __name__ == "__main__":
         lines_a = lines_a[:head]
         lines_b = lines_b[:head]
 
-    print ConsoleDiff(cols=int(options.cols),
+    print(ConsoleDiff(cols=int(options.cols),
                       show_all_spaces=options.show_all_spaces,
                       highlight=options.highlight,
                       line_numbers=options.line_numbers).make_table(
-        lines_a, lines_b, headers[0], headers[1], context=(not options.whole_file), numlines=int(options.numlines))
+        lines_a, lines_b, headers[0], headers[1], context=(not options.whole_file), numlines=int(options.numlines)))


### PR DESCRIPTION
The only changes needed, I think, were parentheses around
print statements and // for truncating division.
Tested on python3.4, python2.7, and python2.6 with jefftk's
example files:

button-a.css
# input, #button {

  width: 350px;
  height: 40px;
  margin: 0px;
  padding: 0px;
  margin-bottom: 15px;
  text-align: center;
}

button-b.css
# input, #button {

  width: 400px;
  height: 40px;
  font-size: 30px;
  margin: 0;
  padding: 0;
  text-align: center;
}
