### PR TITLE
Make 'git icdiff' stay scroll-able on the terminal using 'less'

### DIFF
--- a/git-icdiff
+++ b/git-icdiff
@@ -1,2 +1,2 @@
 #!/bin/bash
-git difftool --no-prompt --extcmd icdiff "$@" | less -R
+git difftool --no-prompt --extcmd "icdiff $@" | less -R


### PR DESCRIPTION
Using the '-R' option retains the color formatting.
