### PR TITLE
git-icdiff tweaks

### DIFF
--- a/git-icdiff
+++ b/git-icdiff
@@ -1,4 +1,4 @@
 #!/bin/sh
-CMD="git difftool --no-prompt --extcmd icdiff $@ | `git config --get core.pager`"
+CMD="git difftool --no-prompt --extcmd icdiff $@ | $(git config --get core.pager)"
 eval $CMD
 


### PR DESCRIPTION
1. Fix quoting of arguments - they were being captured inside the quoted string,
   and not being passed to the `git difftool` command.
2. Use the user's preferred pager setting (I like `less -FXR -x4`)

Thanks for the tool, it seems like it's going to be really useful!
