### PR TITLE
python3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.util import convert_path
 import setuptools
 
 package_data = {}
-execfile('icdiff', package_data)
+exec(open("icdiff").read(), package_data)
 
 setuptools.setup(
     name="icdiff",


### PR DESCRIPTION
execfile has been [removed in Python 3](https://docs.python.org/3.3/whatsnew/3.0.html?highlight=execfile#builtins)
