### PR TITLE
Bugfix/optoins

### DIFF
--- a/icdiff
+++ b/icdiff
@@ -574,7 +574,7 @@ def diff_files(options, a, b):
     for x in [a, b]:
         if os.path.isdir(x):
             codec_print("error: %s is a directory; did you mean to "
-                        "pass --recursive?" % x, optoins)
+                        "pass --recursive?" % x, options)
             return
     try:
         lines_a = read_file(a, options)

--- a/test.sh
+++ b/test.sh
@@ -76,6 +76,7 @@ function check_gold() {
 }
 
 check_gold gold-recursive.txt       --recursive tests/{a,b} --cols=80
+check_gold gold-recursive-msg.txt   tests/{a,b} --cols=80
 check_gold gold-12.txt              tests/input-{1,2}.txt --cols=80
 check_gold gold-3.txt               tests/input-{3,3}.txt
 check_gold gold-45.txt              tests/input-{4,5}.txt --cols=80

--- a/tests/gold-recursive-msg.txt
+++ b/tests/gold-recursive-msg.txt
@@ -1,0 +1,1 @@
+error: tests/a is a directory; did you mean to pass --recursive?


### PR DESCRIPTION
Just a typo that errors like this:
```
$ icdiff ../ .
Traceback (most recent call last):
  File "/usr/local/bin/icdiff", line 603, in <module>
    start()
  File "/usr/local/bin/icdiff", line 511, in start
    diff_files(options, a, b)
  File "/usr/local/bin/icdiff", line 577, in diff_files
    "pass --recursive?" % x, optoins)
NameError: global name 'optoins' is not defined
```

I've fixed it and added a test.