### PR TITLE
Bumped version.

### DIFF
--- a/icdiff
+++ b/icdiff
@@ -19,7 +19,7 @@ import filecmp
 import unicodedata
 import codecs
 
-__version__ = "1.7.2"
+__version__ = "1.7.4"
 
 color_codes = {
     "red":     '\033[0;31m',


### PR DESCRIPTION
Release 1.7.3 already mistakingly reports itself as version 1.7.2, so I thought I'd chime in and bump the version number before it gets overlooked again (especially with the "optoins" typo bug in 1.7.3, the currently latest release, I also instantly stumbled upon).