### PR TITLE
Fix incorrect reported version string for v1.7.3

### DIFF
--- a/icdiff
+++ b/icdiff
@@ -19,7 +19,7 @@ import filecmp
 import unicodedata
 import codecs
 
-__version__ = "1.7.2"
+__version__ = "1.7.3"
 
 color_codes = {
     "red":     '\033[0;31m',


### PR DESCRIPTION
`icdiff --version` reports `1.7.2` despite being version `1.7.3`. Fixes #52.
Tag `v1.7.3` is still incorrect, however.