### PR TITLE
[ICDIFF-61] Handle error on file not found

### DIFF
--- a/icdiff
+++ b/icdiff
@@ -546,6 +546,10 @@ def diff_recursively(options, a, b):
         print_meta("File %s is a file while %s is a directory" % (a, b))
 
 def read_file(fname, options):
+    if not (os.path.isfile(fname) and os.access(fname, os.R_OK)):
+        codec_print(
+            "error: file '%s' is either missing or not readable." % (fname), options)
+        sys.exit(1)
     try:
         with codecs.open(fname, encoding=options.encoding, mode="rb") as inf:
             return inf.readlines()


### PR DESCRIPTION
```
[ec2-user@startrek captain]$ icdiff bootstrap_9.sh bootstrap_10.sh
error: file 'bootstrap_9.sh' is either missing or not readable.
```
