### PR TITLE
Allow named pipe diffing

### DIFF
--- a/icdiff
+++ b/icdiff
@@ -21,6 +21,7 @@ import re
 import filecmp
 import unicodedata
 import codecs
+import stat
 
 __version__ = "1.8.1"
 
@@ -524,7 +525,8 @@ def diff(options, a, b):
     def print_meta(s):
         codec_print(simple_colorize(s, "magenta"), options)
 
-    if os.path.isfile(a) and os.path.isfile(b):
+    if (os.path.isfile(a) or stat.S_ISFIFO(os.stat(a).st_mode)) and \
+       (os.path.isfile(b) or stat.S_ISFIFO(os.stat(b).st_mode)):
         if not filecmp.cmp(a, b, shallow=False):
             diff_files(options, a, b)
 

--- a/test.sh
+++ b/test.sh
@@ -103,6 +103,9 @@ check_gold gold-67-u3.txt           tests/input-{6,7}.txt --cols=80 -U 3
 check_gold gold-tabs-default.txt    tests/input-{8,9}.txt --cols=80
 check_gold gold-tabs-4.txt          tests/input-{8,9}.txt --cols=80 --tabsize=4
 
+check_gold gold-45-file-pipe.txt    tests/input-4.txt <(cat tests/input-5.txt) --cols=80 --no-headers
+check_gold gold-45-pipe-file.txt    <(cat tests/input-4.txt) tests/input-5.txt --cols=80 --no-headers
+check_gold gold-45-pipe-pipe.txt    <(cat tests/input-4.txt) <(cat tests/input-5.txt) --cols=80 --no-headers
 
 if [ ! -z "$INSTALLED" ]; then
   VERSION=$(icdiff --version | awk '{print $NF}')

--- a/tests/gold-45-file-pipe.txt
+++ b/tests/gold-45-file-pipe.txt
@@ -1,0 +1,9 @@
+#input, #button {                       #input, #button {                      
+  width: [1;33m35[m0px;                           width: [1;33m40[m0px;                        
+  height: 40px;                           height: 40px;                        
+                                        [1;32m  font-size: 30px;[m                     
+  margin: 0[1;31mpx[m;                            margin: 0;                           
+  padding: 0[1;31mpx[m;                           padding: 0;                          
+[1;31m  margin-bottom: 15px;[m                                                         
+  text-align: center;                     text-align: center;                  
+}                                       }                                      

--- a/tests/gold-45-pipe-file.txt
+++ b/tests/gold-45-pipe-file.txt
@@ -1,0 +1,9 @@
+#input, #button {                       #input, #button {                      
+  width: [1;33m35[m0px;                           width: [1;33m40[m0px;                        
+  height: 40px;                           height: 40px;                        
+                                        [1;32m  font-size: 30px;[m                     
+  margin: 0[1;31mpx[m;                            margin: 0;                           
+  padding: 0[1;31mpx[m;                           padding: 0;                          
+[1;31m  margin-bottom: 15px;[m                                                         
+  text-align: center;                     text-align: center;                  
+}                                       }                                      

--- a/tests/gold-45-pipe-pipe.txt
+++ b/tests/gold-45-pipe-pipe.txt
@@ -1,0 +1,9 @@
+#input, #button {                       #input, #button {                      
+  width: [1;33m35[m0px;                           width: [1;33m40[m0px;                        
+  height: 40px;                           height: 40px;                        
+                                        [1;32m  font-size: 30px;[m                     
+  margin: 0[1;31mpx[m;                            margin: 0;                           
+  padding: 0[1;31mpx[m;                           padding: 0;                          
+[1;31m  margin-bottom: 15px;[m                                                         
+  text-align: center;                     text-align: center;                  
+}                                       }                                      


### PR DESCRIPTION
This PR for allow [named pipe](https://en.wikipedia.org/wiki/Named_pipe) diffing, 
for example:

```
$ icdiff <(ls -1 ~/) <(ls -1 -a ~/)

$ ls -1 ~/ > my-files
$ icdiff my-files <(ls -1 -a ~/)
$ icdiff <(ls -1 -a ~/) my-files
```

References:
- https://en.wikipedia.org/wiki/Named_pipe
- http://stackoverflow.com/questions/8558884/check-if-file-is-a-named-pipe-fifo-in-python
- https://docs.python.org/3/library/stat.html#stat.S_ISFIFO
