### PR TITLE
Add short alias for oft-used flags

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+1.8.2
+	Add short flags for --highlight (-H), --line-numbers (-N), and --whole-file (-W).
+
 1.8.1
 	Updated remaining copy of unicode test file (b/1)
 

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Show differences between files in a two column view.
                         only
   --encoding=ENCODING   specify the file encoding; defaults to utf8
   --head=HEAD           consider only the first N lines of each file
-  --highlight           color by changing the background color instead of the
+  -H, --highlight       color by changing the background color instead of the
                         foreground color.  Very fast, ugly, displays all
                         changes
   -L LABELS, --label=LABELS
                         override file labels with arbitrary tags. Use twice,
                         one for each file
-  --line-numbers        generate output with line numbers
+  -N, --line-numbers    generate output with line numbers
   --no-bold             use non-bold colors; recommended for with solarized
   --no-headers          don't label the left and right sides with their file
                         names
@@ -49,7 +49,7 @@ Show differences between files in a two column view.
   -U NUM, --unified=NUM, --numlines=NUM
                         how many lines of context to print; can't be combined
                         with --whole-file
-  --whole-file          show the whole file instead of just changed lines and
+  -W, --whole-file      show the whole file instead of just changed lines and
                         context
 ```
 

--- a/icdiff
+++ b/icdiff
@@ -22,7 +22,7 @@ import filecmp
 import unicodedata
 import codecs
 
-__version__ = "1.8.1"
+__version__ = "1.8.2"
 
 color_codes = {
     "red":     '\033[0;31m',

--- a/icdiff
+++ b/icdiff
@@ -439,7 +439,7 @@ def start():
                       help="specify the file encoding; defaults to utf8")
     parser.add_option("--head", default=0,
                       help="consider only the first N lines of each file")
-    parser.add_option("--highlight", default=False,
+    parser.add_option("-H", "--highlight", default=False,
                       action="store_true",
                       help="color by changing the background color instead of "
                       "the foreground color.  Very fast, ugly, displays all "
@@ -450,7 +450,7 @@ def start():
                       dest='labels',
                       help="override file labels with arbitrary tags. "
                       "Use twice, one for each file")
-    parser.add_option("--line-numbers", default=False,
+    parser.add_option("-N", "--line-numbers", default=False,
                       action="store_true",
                       help="generate output with line numbers")
     parser.add_option("--no-bold", default=False,
@@ -480,7 +480,7 @@ def start():
                       metavar="NUM",
                       help="how many lines of context to print; "
                       "can't be combined with --whole-file")
-    parser.add_option("--whole-file", default=False,
+    parser.add_option("-W", "--whole-file", default=False,
                       action="store_true",
                       help="show the whole file instead of just changed "
                       "lines and context")


### PR DESCRIPTION
This adds some short flag for most flags that I find are used often. This saves time typing out the longer flag alternative.