### PR TITLE
Add option to show complete additions and removals when using git difftool

### DIFF
--- a/icdiff
+++ b/icdiff
@@ -21,6 +21,7 @@ import re
 import filecmp
 import unicodedata
 import codecs
+import tempfile
 
 __version__ = "1.8.2"
 
@@ -484,6 +485,9 @@ def start():
                       action="store_true",
                       help="show the whole file instead of just changed "
                       "lines and context")
+    parser.add_option("--show-add-rm", default=False,
+                      action="store_true",
+                      help="show added/removed files")
 
     (options, args) = parser.parse_args()
 
@@ -524,6 +528,11 @@ def diff(options, a, b):
     def print_meta(s):
         codec_print(simple_colorize(s, "magenta"), options)
 
+    dev_nulls = {fn: tempfile.NamedTemporaryFile()
+                 for fn in (a, b)
+                 if fn == os.path.devnull and options.show_add_rm}
+    a, b = [getattr(dev_nulls.get(fn), 'name', fn) for fn in (a, b)]
+
     if os.path.isfile(a) and os.path.isfile(b):
         if not filecmp.cmp(a, b, shallow=False):
             diff_files(options, a, b)
@@ -546,6 +555,9 @@ def diff(options, a, b):
 
     elif os.path.isfile(a) and os.path.isdir(b):
         print_meta("File %s is a file while %s is a directory" % (a, b))
+
+    for fd in dev_nulls.values():
+        fd.close()
 
 def read_file(fname, options):
     try:

--- a/test.sh
+++ b/test.sh
@@ -96,6 +96,9 @@ check_gold gold-45-nh.txt           tests/input-{4,5}.txt --cols=80 --no-headers
 check_gold gold-45-h3.txt           tests/input-{4,5}.txt --cols=80 --head=3
 check_gold gold-45-l.txt            tests/input-{4,5}.txt --cols=80 -L left
 check_gold gold-45-lr.txt           tests/input-{4,5}.txt --cols=80 -L left -L right
+check_gold gold-4dn-sa.txt          tests/input-4.txt /dev/null --cols=80 --show-add-rm -L left -L right
+check_gold gold-dn5-sa.txt          /dev/null tests/input-5.txt --cols=80 --show-add-rm -L left -L right
+check_gold gold-dn5-nsa.txt         /dev/null tests/input-5.txt --cols=80 -L left -L right
 check_gold gold-67.txt              tests/input-{6,7}.txt --cols=80
 check_gold gold-67-wf.txt           tests/input-{6,7}.txt --cols=80 --whole-file
 check_gold gold-67-ln.txt           tests/input-{6,7}.txt --cols=80 --line-numbers

--- a/tests/gold-4dn-sa.txt
+++ b/tests/gold-4dn-sa.txt
@@ -1,0 +1,9 @@
+[0;34mleft[m                                    [0;34mright[m                                  
+[1;31m#input, #button {[m                                                              
+[1;31m  width: 350px;[m                                                                
+[1;31m  height: 40px;[m                                                                
+[1;31m  margin: 0px;[m                                                                 
+[1;31m  padding: 0px;[m                                                                
+[1;31m  margin-bottom: 15px;[m                                                         
+[1;31m  text-align: center;[m                                                          
+[1;31m}[m                                                                              

--- a/tests/gold-dn5-sa.txt
+++ b/tests/gold-dn5-sa.txt
@@ -1,0 +1,9 @@
+[0;34mleft[m                                    [0;34mright[m                                  
+                                        [1;32m#input, #button {[m                      
+                                        [1;32m  width: 400px;[m                        
+                                        [1;32m  height: 40px;[m                        
+                                        [1;32m  font-size: 30px;[m                     
+                                        [1;32m  margin: 0;[m                           
+                                        [1;32m  padding: 0;[m                          
+                                        [1;32m  text-align: center;[m                  
+                                        [1;32m}[m                                      


### PR DESCRIPTION
The main motivator of this change is to improve the experience of reviewing a PR using *icdiff* as a external tool for `git difftool` command, by showing the files removed/added by that PR. 

E.g. 
```bash
git --version
# git version 2.10.0
git init code-review
cd code-review
echo "Hello" > a.txt
git add a.txt
git commit --all -m "first commit"
echo "world" > b.txt
git add  b.txt
git commit --all -m "Add b.txt"
git difftool -y -x 'icdiff' HEAD~1 HEAD
# the addition of b.txt won't be shown by the above command
# obviously using the git-icdiff wrapper won't help much
```

The reason for the above seems to be how the underlying machinery of `git difftool` calls icdiff. In the above case: 
    - for b.txt file, *icdiff* will be called by [this script](https://github.com/git/git/blob/master/git-difftool--helper.sh#L62) with the following args `/dev/null b.txt`. 
    - the above script gets its input from the output of `git diff` which behaves as specified in its [man page](https://github.com/git/git/blob/master/Documentation/diff-generate-patch.txt#L144): *"Similar to two-line header for traditional unified diff format, /dev/null is used to signal created or deleted files"*
    - now my C is a bit rusty but grep-ing the source code it seems [this is where](https://github.com/git/git/blob/master/diff.c#L2406) git uses "/dev/null" as a hardcoded value to mark additions/removals in it's diff output, so I'm assuming is quite safe for us to use it for the detection of added/removed files

I'm afraid the naming of the option `--show-add-rm` is not the most fortunate, so I'm happy to change it with a better one.

The option  is by default False because I thought there were reasons for not having this functionality so I thought I should keep the default behaviour as is. 

I tried to keep the impact to the rest of the code  to a minimum that's why I ended up creating a tmp file and passing its name further down.