### PR TITLE
Print message 'Binary files xxx and yyy differ' when diff two binary files. 

### DIFF
--- a/icdiff
+++ b/icdiff
@@ -21,6 +21,7 @@ import re
 import filecmp
 import unicodedata
 import codecs
+import mimetypes
 
 __version__ = "1.9.0"
 
@@ -591,6 +592,13 @@ def diff_files(options, a, b):
 
     assert not os.path.isdir(a)
     assert not os.path.isdir(b)
+
+    mime_a = mimetypes.guess_type(a)
+    mime_b = mimetypes.guess_type(b)
+    if mime_a[0] == 'application/octet-stream' or \
+            mime_b[0] == 'application/octet-stream':
+        codec_print("Binary files %s and %s differ" % (a, b), options)
+        return
 
     try:
         lines_a = read_file(a, options)


### PR DESCRIPTION
When I diff two binary files with icdiff, it print message, not valid
whith encoding 'utf-8'. The command diff print 'Binary files xxx and
yyy diff'. I think the icdiff should be like diff.

How I do it?
Before diff two files, I get the files' mime. If one of them is
'application/octet-stream', I print the message and return the diff_files function.