### PR TITLE
Configure options of git-icdiff with ~/.gitconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ To install this as a tool you can use with git, copy
 git icdiff
 ```
 
+If you have installed `git-icdiff`, you can configure their options adding to your `~/.gitconfig`:
+
+```
+[icdiff]
+    options = --highlight --line-numbers
+``` 
 
 ## Using with subversion
 

--- a/git-icdiff
+++ b/git-icdiff
@@ -1,5 +1,6 @@
 #!/bin/sh
 GITPAGER=$(git config --get core.pager)
+ICDIFF_OPTIONS=$(git config --get icdiff.options)
 
 if [ -z "$GITPAGER" ]; then
   GITPAGER="$PAGER"
@@ -13,4 +14,4 @@ if [ "$GITPAGER" = "more" -o "$GITPAGER" = "less" ]; then
   GITPAGER="$GITPAGER -R"
 fi
 
-git difftool --no-prompt --extcmd icdiff "$@" | $GITPAGER
+git difftool --no-prompt --extcmd="icdiff $ICDIFF_OPTIONS $@" | $GITPAGER


### PR DESCRIPTION
Allow to configure the options of `git-icdiff` using your `~/.gitconfig`, so you can personalice the output.

For example, modify your `~/.gitconfig` and add:

```
[icdiff]
    options = --highlight --line-numbers
``` 
