### PR TITLE
Ignore commented lines that begin with a hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Show differences between files in a two column view.
   --cols=COLS           specify the width of the screen. Autodetection is Unix
                         only
   --encoding=ENCODING   specify the file encoding; defaults to utf8
+  -E MATCHER, --exclude-lines=MATCHER
+                        Do not diff lines that match this regex. Not
+                        compatible with the 'line-numbers' option
   --head=HEAD           consider only the first N lines of each file
   -H, --highlight       color by changing the background color instead of the
                         foreground color.  Very fast, ugly, displays all
@@ -41,7 +44,8 @@ Show differences between files in a two column view.
   -L LABELS, --label=LABELS
                         override file labels with arbitrary tags. Use twice,
                         one for each file
-  -N, --line-numbers    generate output with line numbers
+  -N, --line-numbers    generate output with line numbers. Not compatible with
+                        the 'exclude-lines' option.
   --no-bold             use non-bold colors; recommended for solarized
   --no-headers          don't label the left and right sides with their file
                         names

--- a/icdiff
+++ b/icdiff
@@ -474,6 +474,12 @@ def create_option_parser():
                       "Unix only")
     parser.add_option("--encoding", default="utf-8",
                       help="specify the file encoding; defaults to utf8")
+    parser.add_option("-E", "--exclude-lines",
+                      action="store",
+                      type="string",
+                      dest='matcher',
+                      help="Do not diff lines that match this regex. Not "
+                      "compatible with the 'line-numbers' option")
     parser.add_option("--head", default=0,
                       help="consider only the first N lines of each file")
     parser.add_option("-H", "--highlight", default=False,
@@ -489,7 +495,8 @@ def create_option_parser():
                       "Use twice, one for each file")
     parser.add_option("-N", "--line-numbers", default=False,
                       action="store_true",
-                      help="generate output with line numbers")
+                      help="generate output with line numbers. Not compatible "
+                      "with the 'exclude-lines' option.")
     parser.add_option("--no-bold", default=False,
                       action="store_true",
                       help="use non-bold colors; recommended for solarized")
@@ -654,6 +661,12 @@ def diff_files(options, a, b):
     if head != 0:
         lines_a = lines_a[:head]
         lines_b = lines_b[:head]
+
+    if options.matcher:
+        lines_a = [line_a for line_a in lines_a if
+                   not re.search(options.matcher, line_a)]
+        lines_b = [line_b for line_b in lines_b if
+                   not re.search(options.matcher, line_b)]
 
     if options.no_bold:
         for key in color_mapping:

--- a/test.sh
+++ b/test.sh
@@ -80,6 +80,7 @@ function check_gold() {
 }
 
 check_gold gold-recursive.txt       --recursive tests/{a,b} --cols=80
+check_gold gold-exclude.txt         --exclude-lines '^#|  pad' tests/input-4-cr.txt tests/input-4-partial-cr.txt --cols=80
 check_gold gold-dir.txt             tests/{a,b} --cols=80
 check_gold gold-12.txt              tests/input-{1,2}.txt --cols=80
 check_gold gold-3.txt               tests/input-{3,3}.txt

--- a/tests/gold-exclude.txt
+++ b/tests/gold-exclude.txt
@@ -1,0 +1,7 @@
+[0;34mtests/input-4-cr.txt[m                    [0;34mtests/input-4-partial-cr.txt[m           
+  width: 350px;                           width: 350px;                        
+  height: 40px;                           height: 40px;                        
+  margin: 0px;                            margin: 0px;                         
+  margin-bottom: 15px;                    margin-bottom: 15px;                 
+  text-align: center;[1;31m\r[m                   text-align: center;                  
+}                                       }                                      


### PR DESCRIPTION
Hi Jeff,

Please review my change to allow commented lines to be ignored during icdiff.

Thanks!