### PR TITLE
Allow setting colors via environment var

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Show differences between files in a two column view.
                         '--color-map=separator:white,description:cyan
 ```
 
+Colors can be set via environment variable ICDIFF_COLORS too.
+
 ## Using with Git
 
 To see what it looks like, try:

--- a/icdiff
+++ b/icdiff
@@ -45,7 +45,6 @@ color_codes = {
     "white_bold":   '\033[1;37m',
 }
 
-
 color_mapping = {
     "add": "green_bold",
     "subtract": "red_bold",
@@ -55,6 +54,16 @@ color_mapping = {
     "meta": "magenta",
     "line-numbers": "white",
 }
+
+
+def _split(s, sep):
+    return list(map(str.strip, s.split(sep)))
+
+
+color_str = os.getenv('ICDIFF_COLORS')
+if color_str:
+    env_map = dict(tuple(_split(s, ':')) for s in _split(color_str, ','))
+    color_mapping.update(env_map)
 
 
 class ConsoleDiff(object):


### PR DESCRIPTION
Colors can be now specified via environment variable `ICDIFF_COLORS` using the same format as in command line.