### PR TITLE
git-icdiff: start search for pager in icdiff.pager

### DIFF
--- a/git-icdiff
+++ b/git-icdiff
@@ -1,17 +1,13 @@
 #!/bin/sh
-GITPAGER=$(git config --get core.pager)
 ICDIFF_OPTIONS=$(git config --get icdiff.options)
+GITPAGER=$(git config --get icdiff.pager)
 
 if [ -z "$GITPAGER" ]; then
-  GITPAGER="$PAGER"
-fi
-
-if [ -z "$GITPAGER" ]; then
-  GITPAGER="less"
+  GITPAGER=$(git config --get --default "${PAGER:-less}" core.pager)
 fi
 
 if [ "$GITPAGER" = "more" ] || [ "$GITPAGER" = "less" ]; then
   GITPAGER="$GITPAGER -R"
 fi
 
-git difftool --no-prompt --extcmd="icdiff $ICDIFF_OPTIONS" $* | $GITPAGER
+git difftool --no-prompt --extcmd="icdiff $ICDIFF_OPTIONS" "$@" | $GITPAGER


### PR DESCRIPTION
This changes `git-icdiff` so it starts looking for the pager in `icdiff.pager`, before looking at `core.pager`, `$PAGER` and falling back to `less`.

Passed it through shellcheck `v0.6.0+git107.293c3b2` (built from master on 2016-03-03), and changed the `$*` to a `"$@"` as a consequence.