### PR TITLE
feat: show the real file name when displaying git diff result

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ python:
 script:
   - pip install -r requirements-dev.txt
   - ./test.sh python
+git:
+  depth: false

--- a/git-icdiff
+++ b/git-icdiff
@@ -1,5 +1,6 @@
 #!/bin/sh
 ICDIFF_OPTIONS=$(git config --get icdiff.options)
+ICDIFF_OPTIONS="${ICDIFF_OPTIONS} --is-git-diff"
 GITPAGER=$(git config --get icdiff.pager)
 
 if [ -z "$GITPAGER" ]; then

--- a/icdiff
+++ b/icdiff
@@ -540,6 +540,9 @@ def create_option_parser():
                                for x in sorted(color_mapping.items())) + "'"
                       ".  You don't have to override all of them: "
                       "'--color-map=separator:white,description:cyan")
+    parser.add_option("--is-git-diff", default=False,
+                      action="store_true",
+                      help="Show the real file name when displaying git-diff result")
     return parser
 
 
@@ -667,18 +670,26 @@ def format_label(path, label="{path}"):
 
 
 def diff_files(options, a, b):
-    if options.labels:
-        if len(options.labels) == 2:
-            headers = [
-                format_label(a, options.labels[0]),
-                format_label(b, options.labels[1]),
-            ]
-        else:
-            codec_print("error: to use arbitrary file labels, "
-                        "specify -L twice.", options)
-            return
+    if options.is_git_diff is True:
+        # Use $BASE as label when displaying git-diff result
+        base = os.getenv("BASE")
+        headers = [
+            format_label(a, base),
+            format_label(b, base)
+        ]
     else:
-        headers = a, b
+        if options.labels:
+            if len(options.labels) == 2:
+                headers = [
+                    format_label(a, options.labels[0]),
+                    format_label(b, options.labels[1]),
+                ]
+            else:
+                codec_print("error: to use arbitrary file labels, "
+                            "specify -L twice.", options)
+                return
+        else:
+            headers = a, b
     if options.no_headers:
         headers = None, None
 

--- a/icdiff
+++ b/icdiff
@@ -542,7 +542,8 @@ def create_option_parser():
                       "'--color-map=separator:white,description:cyan")
     parser.add_option("--is-git-diff", default=False,
                       action="store_true",
-                      help="Show the real file name when displaying git-diff result")
+                      help="Show the real file name when displaying "
+                      "git-diff result")
     return parser
 
 

--- a/test.sh
+++ b/test.sh
@@ -93,7 +93,7 @@ function check_git_diff() {
     # Set default args when first time check git diff
     yes | git difftool --extcmd icdiff > /dev/null
     git config --global icdiff.options '--cols=80'
-    export PATH=$PATH:"$(pwd)/git-icdiff"
+    export PATH=$PATH:"$(pwd)"
   fi
   local tmp=/tmp/git-icdiff.output
   git icdiff $1 $2 &> $tmp

--- a/test.sh
+++ b/test.sh
@@ -93,6 +93,7 @@ function check_git_diff() {
     # Set default args when first time check git diff
     yes | git difftool --extcmd icdiff > /dev/null
     git config --global icdiff.options '--cols=80'
+    export PATH=$PATH:"$(pwd)/git-icdiff"
   fi
   local tmp=/tmp/git-icdiff.output
   git icdiff $1 $2 &> $tmp

--- a/test.sh
+++ b/test.sh
@@ -144,7 +144,7 @@ check_gold gold-subcolors-bad-color tests/input-{1,2}.txt --cols=80 --color-map=
 check_gold gold-subcolors-bad-cat tests/input-{1,2}.txt --cols=80 --color-map='chnge:magenta,description:cyan_bold'
 check_gold gold-subcolors-bad-fmt tests/input-{1,2}.txt --cols=80 --color-map='change:magenta:gold,description:cyan_bold'
 check_gold gold-bad-encoding.txt tests/input-{1,2}.txt --encoding=nonexistend_encoding
-check_git_diff gitdiff-only-newlines.txt 4e862056296aa810a46caaf2ac1b0feb82c5e330~1 4e862056296aa810a46caaf2ac1b0feb82c5e330
+check_git_diff gitdiff-only-newlines.txt 4e86205629~1 4e86205629
 
 # Testing pipe behavior doesn't fit well with the check_gold system
 $INVOCATION tests/input-{4,5}.txt 2>/tmp/icdiff-pipe-error-output | head -n 1

--- a/test.sh
+++ b/test.sh
@@ -81,6 +81,29 @@ function check_gold() {
   fi
 }
 
+FIRST_TIME_CHECK_GIT_DIFF = true
+function check_git_diff() {
+  local gitdiff=tests/$1
+  shift
+
+  echo "    check_gitdiff $gitdiff matches git icdiff $@"
+  # Check when using icdiff in git
+  if $FIRST_TIME_CHECK_GIT_DIFF; then
+    FIRST_TIME_CHECK_GIT_DIFF=false
+    # Set default args when first time check git diff
+    yes | git difftool --extcmd icdiff > /dev/null
+    git config --global icdiff.options '--cols=80'
+  fi
+  local tmp=/tmp/git-icdiff.output
+  git icdiff $1 $2 &> $tmp
+  if ! diff $tmp $gitdiff; then
+    echo "Got: ($tmp)"
+    cat $tmp
+    echo "Expected: ($gitdiff)"
+    fail
+  fi
+}
+
 check_gold gold-recursive.txt       --recursive tests/{a,b} --cols=80
 check_gold gold-exclude.txt         --exclude-lines '^#|  pad' tests/input-4-cr.txt tests/input-4-partial-cr.txt --cols=80
 check_gold gold-dir.txt             tests/{a,b} --cols=80
@@ -120,6 +143,7 @@ check_gold gold-subcolors-bad-color tests/input-{1,2}.txt --cols=80 --color-map=
 check_gold gold-subcolors-bad-cat tests/input-{1,2}.txt --cols=80 --color-map='chnge:magenta,description:cyan_bold'
 check_gold gold-subcolors-bad-fmt tests/input-{1,2}.txt --cols=80 --color-map='change:magenta:gold,description:cyan_bold'
 check_gold gold-bad-encoding.txt tests/input-{1,2}.txt --encoding=nonexistend_encoding
+check_git_diff gitdiff-only-newlines.txt 4e862056296aa810a46caaf2ac1b0feb82c5e330~1 4e862056296aa810a46caaf2ac1b0feb82c5e330
 
 # Testing pipe behavior doesn't fit well with the check_gold system
 $INVOCATION tests/input-{4,5}.txt 2>/tmp/icdiff-pipe-error-output | head -n 1

--- a/tests/gitdiff-only-newlines.txt
+++ b/tests/gitdiff-only-newlines.txt
@@ -1,0 +1,22 @@
+[0;34mREADME[m                                  [0;34mREADME[m                                 
+  --show-all-spaces    color all non-m    --show-all-spaces    color all non-m 
+atching whitespace including            atching whitespace including           
+                       that which is n                         that which is n 
+ot needed for drawing the eye to        ot needed for drawing the eye to       
+                       changes. Slow,                          changes. Slow,  
+ugly, displays all changes              ugly, displays all changes             
+  --print-headers      label the left     --print-headers      label the left  
+and right sides with their file         and right sides with their file        
+                       names                                   names           
+                                        [7;32m [m                                      
+                                        [1;32mLicense:[m                               
+                                        [7;32m [m                                      
+                                        [1;32m  This file is derived from difflib.Ht[m 
+                                        [1;32mmlDiff which is under the license:[m     
+                                        [7;32m [m                                      
+                                        [1;32m    http://www.python.org/download/rel[m 
+                                        [1;32meases/2.6.2/license/[m                   
+                                        [7;32m [m                                      
+                                        [1;32m  I release my changes here under the [m 
+                                        [1;32msame license.  This is GPL compatible.[m 
+                                        [7;32m  [m                                     


### PR DESCRIPTION
### Before my fix
When using `icdiff` to display the git diff result, the file path is not unrecognizable for human.

Just like this
<img width="1277" alt="filename-unrecognizable" src="https://user-images.githubusercontent.com/16591903/61282617-40a32700-a7ee-11e9-91ee-5e67b77d4dfc.png">
Let's take a look at the file paths which are:
1. ChangeLog
    * `/var/folders/h1/jvqp6h_50dvfnjz56cv8ssq4067fyr/T//zGL6ka_ChangeLog`
    * `/var/folders/h1/jvqp6h_50dvfnjz56cv8ssq4067fyr/T//1s1fqa_ChangeLog`
2. MANIFEST.in
    * `/var/folders/h1/jvqp6h_50dvfnjz56cv8ssq4067fyr/T//LeC2ab_MANIFEST.in`
    * `/var/folders/h1/jvqp6h_50dvfnjz56cv8ssq4067fyr/T//12boab_MANIFEST.in`

If your file located in the root directory, you may can find the file name according to the tail.  
But If your file located in the subdirectory, the subdirectory will be missed, you will only get the file name.   
Let's say the file path is `${project_root}/a/b/c/file.txt`, the file path displayed by icdiff will be like this `/var/folders/h1/jvqp6h_50dvfnjz56cv8ssq4067fyr/T//12boab_file.txt`

### After my fix
The file path will be easy to read, and the dir-path of files which located in subdirectory will not miss.
<img width="1277" alt="filename-corrected" src="https://user-images.githubusercontent.com/16591903/61283644-0a66a700-a7f0-11e9-905a-463f91d86f4b.png">

### How I fix it
* Add a arg which named `--is-git-diff` when call `git-icdiff`
* Change the header to env variable `$BASE`

PS: see more details about `$BASE` [here](https://git-scm.com/docs/git-difftool#Documentation/git-difftool.txt---extcmdltcommandgt)