### PR TITLE
fix: fix the unknown option 'default' error when call git config

### DIFF
--- a/git-icdiff
+++ b/git-icdiff
@@ -3,7 +3,11 @@ ICDIFF_OPTIONS=$(git config --get icdiff.options)
 GITPAGER=$(git config --get icdiff.pager)
 
 if [ -z "$GITPAGER" ]; then
-  GITPAGER=$(git config --get --default "${PAGER:-less}" core.pager)
+  if git config --get core.pager; then
+    GITPAGER=$(git config --get core.pager)
+  else
+    GITPAGER="${PAGER:-less}"
+  fi
 fi
 
 if [ "$GITPAGER" = "more" ] || [ "$GITPAGER" = "less" ]; then


### PR DESCRIPTION
When I try to get git diff result between **HEAD~1** and **HEAD**, I run the command
```shell
git icdiff HEAD~1 HEAD
```
But I get this complain:
```shell
error: unknown option `default'
usage: git config [<options>]
```
<img width="1267" alt="git-icdiff-error" src="https://user-images.githubusercontent.com/16591903/61295256-31ca6d80-a80a-11e9-84eb-f872734cd20c.png">

The git version I'm using is `v2.17.2`.  
I also test on version `2.7.4` on Ubuntu, and it fails too.

### Then I fix the `git-icdiff` shell script