### PR TITLE
git-icdiff: Stop printing core.pager value when icdiff.pager does not exist

### DIFF
--- a/git-icdiff
+++ b/git-icdiff
@@ -4,11 +4,11 @@ ICDIFF_OPTIONS="${ICDIFF_OPTIONS} --is-git-diff"
 GITPAGER=$(git config --get icdiff.pager)
 
 if [ -z "$GITPAGER" ]; then
-  if git config --get core.pager; then
-    GITPAGER=$(git config --get core.pager)
-  else
-    GITPAGER="${PAGER:-less}"
-  fi
+  GITPAGER=$(git config --get core.pager)
+fi
+
+if [ -z "$GITPAGER" ]; then
+  GITPAGER="${PAGER:-less}"
 fi
 
 if [ "$GITPAGER" = "more" ] || [ "$GITPAGER" = "less" ]; then


### PR DESCRIPTION
**Problem**
When git-icdiff cannot find a value for `icdiff.pager` it falls back to `core.pager`. During this fallback, a check is performed within an if clause for the existence of a `core.pager` value. Depending on the shell and the existence of a value, that check causes the value to be printed. 

**Update**
This change removes the check and instead gets the `core.pager` value when `icdiff.pager` does not exist within a subshell, preventing the value from being printed. If neither gitconfig pager exists, the fallback continues to fallback to the PAGER to maintain current behavior.

**Test Case**

```zsh
# Only tested on zsh 5.8
git config --global --unset icdiff.pager
git config --global core.pager less
git-icdiff
```

When run before the patch is applied, "less" is printed to the console.
When run after the patch is applied, "less" is not printed to the console.