### PR TITLE
git-icdiff: Match first word of GITPAGER

### DIFF
--- a/git-icdiff
+++ b/git-icdiff
@@ -11,7 +11,7 @@ if [ -z "$GITPAGER" ]; then
   GITPAGER="${PAGER:-less}"
 fi
 
-if [ "$GITPAGER" = "more" ] || [ "$GITPAGER" = "less" ]; then
+if [ "${GITPAGER%% *}" = "more" ] || [ "${GITPAGER%% *}" = "less" ]; then
   GITPAGER="$GITPAGER -R"
 fi
 


### PR DESCRIPTION
For users that have set `core.pager` to `less` with option flags, this removes the need to duplicate that setting into `icdiff.pager`.