### PR TITLE
Add an environment variable `ICDIFF_DEFAULTS` to allow setting default flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ Show differences between files in a two column view.
                         '--color-map=separator:white,description:cyan
 ```
 
+The environment variable `ICDIFF_DEFAULTS` can be set to a
+space delimited list of default flag values. For example:
+
+  `export ICDIFF_DEFAULTS='-N -U3 --color-map=description:magenta_bold,separator:magenta_bold'`
+
 ## Using with Git
 
 To see what it looks like, try:

--- a/icdiff
+++ b/icdiff
@@ -601,12 +601,18 @@ def set_cols_option(options):
 def validate_has_two_arguments(parser, args):
     if len(args) != 2:
         parser.print_help()
+        print("\nThe environment variable ICDIFF_DEFAULTS can be set to a\n"
+              "space delimited list of default flag values.")
         sys.exit()
 
 
 def start():
     parser = create_option_parser()
-    options, args = parser.parse_args()
+    arguments = sys.argv[1:]
+    defaults = os.getenv("ICDIFF_DEFAULTS")
+    if defaults != None:
+        arguments = defaults.split() + arguments
+    options, args = parser.parse_args(arguments)
     validate_has_two_arguments(parser, args)
     if not options.cols:
         set_cols_option(options)


### PR DESCRIPTION
I'm not 100% happy with this because there's no way to override boolean
options using `optparse`.  i.e. if `ICDIFF_DEFAULTS=-N` there is no way
to override that on the command line.

Switching to `argparse` would allow that via `BooleanOptionalAction` but
that requires python 3.9.

With `optparse`, I could also add `no-XXX` flags for all the existing
boolean flags - LMK.

I use the exact string I put in the `README` FYI. I set that up in my VCS but I'd like to have it in effect all the time.