### PR TITLE
Set process exit code for shell in case of errors and file differences

### DIFF
--- a/icdiff
+++ b/icdiff
@@ -27,8 +27,8 @@ __version__ = "2.0.4"
 
 # Exit code constants
 EXIT_CODE_SUCCESS = 0
-EXIT_CODE_DIFF    = 1
-EXIT_CODE_ERROR   = 2
+EXIT_CODE_DIFF = 1
+EXIT_CODE_ERROR = 2
 
 color_codes = {
     "black":   '\033[0;30m',
@@ -694,6 +694,7 @@ def diff(options, a, b):
 
     return diffs_found
 
+
 def read_file(fname, options):
     try:
         with codecs.open(fname, encoding=options.encoding, mode="rb") as inf:
@@ -809,6 +810,7 @@ def diff_files(options, a, b):
         sys.stdout.flush()
 
     return diff_found
+
 
 if __name__ == "__main__":
     start()

--- a/icdiff
+++ b/icdiff
@@ -605,13 +605,14 @@ def validate_has_two_arguments(parser, args):
 
 
 def start():
+    diffs_found = False
     parser = create_option_parser()
     options, args = parser.parse_args()
     validate_has_two_arguments(parser, args)
     if not options.cols:
         set_cols_option(options)
     try:
-        diff(options, *args)
+        diffs_found = diff(options, *args)
     except KeyboardInterrupt:
         pass
     except IOError as e:
@@ -626,7 +627,7 @@ def start():
     # See: https://stackoverflow.com/questions/26692284/...
     #      ...how-to-prevent-brokenpipeerror-when-doing-a-flush-in-python
     sys.stderr.close()
-    sys.exit(0)
+    sys.exit(1 if diffs_found else 0)
 
 
 def codec_print(s, options):
@@ -641,6 +642,9 @@ def diff(options, a, b):
     def print_meta(s):
         codec_print(simple_colorize(s, "meta"), options)
 
+    # We start out and assume that no diffs have been found (so far)
+    diffs_found = False
+
     # Don't use os.path.isfile; it returns False for file-like entities like
     # bash's process substitution (/dev/fd/N).
     is_a_file = not os.path.isdir(a)
@@ -649,7 +653,7 @@ def diff(options, a, b):
     if is_a_file and is_b_file:
         try:
             if not filecmp.cmp(a, b, shallow=False):
-                diff_files(options, a, b)
+                diffs_found = diffs_found | diff_files(options, a, b)
             elif options.report_identical_files:
                 print("Files %s and %s are identical." % (a, b))
         except OSError as e:
@@ -668,15 +672,18 @@ def diff(options, a, b):
             elif child not in a_contents:
                 print_meta("Only in %s: %s" % (b, child))
             elif options.recursive:
-                diff(options,
-                     os.path.join(a, child),
-                     os.path.join(b, child))
+                diffs_found = diffs_found | diff(options,
+                                                 os.path.join(a, child),
+                                                 os.path.join(b, child))
     elif not is_a_file and is_b_file:
         print_meta("File %s is a directory while %s is a file" % (a, b))
+        diffs_found = True
 
     elif is_a_file and not is_b_file:
         print_meta("File %s is a file while %s is a directory" % (a, b))
+        diffs_found = True
 
+    return diffs_found
 
 def read_file(fname, options):
     try:
@@ -705,6 +712,7 @@ def format_label(path, label="{path}"):
 
 
 def diff_files(options, a, b):
+    diff_found = False
     if options.is_git_diff is True:
         # Use $BASE as label when displaying git-diff result
         base = os.getenv("BASE")
@@ -749,6 +757,9 @@ def diff_files(options, a, b):
         lines_b = [line_b for line_b in lines_b if
                    not re.search(options.matcher, line_b)]
 
+    # Determine if a difference has been detected
+    diff_found = len(lines_a) | len(lines_b)
+
     if options.no_bold:
         for key in color_mapping:
             color_mapping[key] = color_mapping[key].replace("_bold", "")
@@ -788,6 +799,7 @@ def diff_files(options, a, b):
         codec_print(line, options)
         sys.stdout.flush()
 
+    return diff_found
 
 if __name__ == "__main__":
     start()

--- a/icdiff
+++ b/icdiff
@@ -25,6 +25,11 @@ import codecs
 
 __version__ = "2.0.4"
 
+# Exit code constants
+EXIT_CODE_SUCCESS = 0
+EXIT_CODE_DIFF    = 1
+EXIT_CODE_ERROR   = 2
+
 color_codes = {
     "black":   '\033[0;30m',
     "red":     '\033[0;31m',
@@ -484,6 +489,10 @@ def create_option_parser():
                       "Unix only")
     parser.add_option("--encoding", default="utf-8",
                       help="specify the file encoding; defaults to utf8")
+    parser.add_option("-e", "--error-code", default=False,
+                      action="store_true",
+                      help="Set error code if differences have been detected "
+                      "in compared files")
     parser.add_option("-E", "--exclude-lines",
                       action="store",
                       type="string",
@@ -601,7 +610,7 @@ def set_cols_option(options):
 def validate_has_two_arguments(parser, args):
     if len(args) != 2:
         parser.print_help()
-        sys.exit(2)
+        sys.exit(EXIT_CODE_DIFF)
 
 
 def start():
@@ -627,7 +636,7 @@ def start():
     # See: https://stackoverflow.com/questions/26692284/...
     #      ...how-to-prevent-brokenpipeerror-when-doing-a-flush-in-python
     sys.stderr.close()
-    sys.exit(1 if diffs_found else 0)
+    sys.exit(EXIT_CODE_DIFF if diffs_found else EXIT_CODE_SUCCESS)
 
 
 def codec_print(s, options):
@@ -698,7 +707,7 @@ def read_file(fname, options):
         codec_print(
             "error: encoding '%s' was not found." %
             (options.encoding), options)
-        sys.exit(1)
+        sys.exit(EXIT_CODE_ERROR)
 
 
 def format_label(path, label="{path}"):
@@ -774,14 +783,14 @@ def diff_files(options, a, b):
                     "Invalid category '%s' in '%s'.  Valid categories are: %s."
                     % (category, command_for_errors,
                        ", ".join(sorted(color_mapping.keys()))))
-                sys.exit(1)
+                sys.exit(EXIT_CODE_ERROR)
 
             if color not in color_codes:
                 print("Invalid color '%s' in '%s'.  Valid colors are: %s."
                       % (color, command_for_errors,
                          ", ".join([raw_colorize(x, x)
                                     for x in sorted(color_codes.keys())])))
-                sys.exit(1)
+                sys.exit(EXIT_CODE_ERROR)
 
             color_mapping[category] = color
 

--- a/icdiff
+++ b/icdiff
@@ -489,10 +489,6 @@ def create_option_parser():
                       "Unix only")
     parser.add_option("--encoding", default="utf-8",
                       help="specify the file encoding; defaults to utf8")
-    parser.add_option("-e", "--error-code", default=False,
-                      action="store_true",
-                      help="Set error code if differences have been detected "
-                      "in compared files")
     parser.add_option("-E", "--exclude-lines",
                       action="store",
                       type="string",

--- a/icdiff
+++ b/icdiff
@@ -739,7 +739,7 @@ def diff_files(options, a, b):
             else:
                 codec_print("error: to use arbitrary file labels, "
                             "specify -L twice.", options)
-                return
+                return diff_found
         else:
             headers = a, b
     if options.no_headers:
@@ -754,7 +754,7 @@ def diff_files(options, a, b):
         lines_a = read_file(a, options)
         lines_b = read_file(b, options)
     except UnicodeDecodeError:
-        return
+        return diff_found
 
     if head != 0:
         lines_a = lines_a[:head]

--- a/icdiff
+++ b/icdiff
@@ -668,6 +668,7 @@ def diff(options, a, b):
         except OSError as e:
             if e.errno == errno.ENOENT:
                 print_meta("error: file '%s' was not found" % e.filename)
+                sys.exit(EXIT_CODE_ERROR)
             else:
                 raise(e)
 
@@ -716,7 +717,7 @@ def format_label(path, label="{path}"):
 
     Example:
       For file `/foo/bar.py` and label "Yours: {basename}" -
-      The ouptut is "Yours: bar.py"
+      The output is "Yours: bar.py"
     """
     return label.format(path=path, basename=os.path.basename(path))
 
@@ -740,7 +741,7 @@ def diff_files(options, a, b):
             else:
                 codec_print("error: to use arbitrary file labels, "
                             "specify -L twice.", options)
-                return diff_found
+                sys.exit(EXIT_CODE_ERROR)
         else:
             headers = a, b
     if options.no_headers:

--- a/icdiff
+++ b/icdiff
@@ -601,7 +601,7 @@ def set_cols_option(options):
 def validate_has_two_arguments(parser, args):
     if len(args) != 2:
         parser.print_help()
-        sys.exit()
+        sys.exit(2)
 
 
 def start():
@@ -626,6 +626,7 @@ def start():
     # See: https://stackoverflow.com/questions/26692284/...
     #      ...how-to-prevent-brokenpipeerror-when-doing-a-flush-in-python
     sys.stderr.close()
+    sys.exit(0)
 
 
 def codec_print(s, options):
@@ -690,7 +691,7 @@ def read_file(fname, options):
         codec_print(
             "error: encoding '%s' was not found." %
             (options.encoding), options)
-        sys.exit()
+        sys.exit(1)
 
 
 def format_label(path, label="{path}"):
@@ -762,14 +763,14 @@ def diff_files(options, a, b):
                     "Invalid category '%s' in '%s'.  Valid categories are: %s."
                     % (category, command_for_errors,
                        ", ".join(sorted(color_mapping.keys()))))
-                sys.exit()
+                sys.exit(1)
 
             if color not in color_codes:
                 print("Invalid color '%s' in '%s'.  Valid colors are: %s."
                       % (color, command_for_errors,
                          ", ".join([raw_colorize(x, x)
                                     for x in sorted(color_codes.keys())])))
-                sys.exit()
+                sys.exit(1)
 
             color_mapping[category] = color
 

--- a/test.sh
+++ b/test.sh
@@ -44,7 +44,10 @@ function fail() {
 }
 
 function check_gold() {
-  local gold=tests/$1
+  local error_code
+  local expect=$1
+  local gold=tests/$2
+  shift
   shift
 
   if [ $TEST_NAME != "all" -a $TEST_NAME != $gold ]; then
@@ -54,6 +57,7 @@ function check_gold() {
   echo "    check_gold $gold matches $@"
   local tmp=/tmp/icdiff.output
   $INVOCATION "$@" &> $tmp
+  error_code=$?
 
   if $REGOLD; then
     if [ -e $gold ] && diff $tmp $gold > /dev/null; then
@@ -77,6 +81,12 @@ function check_gold() {
     cat $tmp
     echo "Expected: ($gold)"
     cat $gold
+    fail
+  fi
+
+  if [[ $error_code != $expect ]]; then
+    echo "Got error code:      $error_code"
+    echo "Expected error code: $expect"
     fail
   fi
 }
@@ -105,47 +115,47 @@ function check_git_diff() {
   fi
 }
 
-check_gold gold-recursive.txt       --recursive tests/{a,b} --cols=80
-check_gold gold-exclude.txt         --exclude-lines '^#|  pad' tests/input-4-cr.txt tests/input-4-partial-cr.txt --cols=80
-check_gold gold-dir.txt             tests/{a,b} --cols=80
-check_gold gold-12.txt              tests/input-{1,2}.txt --cols=80
-check_gold gold-12-t.txt            tests/input-{1,2}.txt --cols=80 --truncate
-check_gold gold-3.txt               tests/input-{3,3}.txt
-check_gold gold-45.txt              tests/input-{4,5}.txt --cols=80
-check_gold gold-45-95.txt           tests/input-{4,5}.txt --cols=95
-check_gold gold-45-sas.txt          tests/input-{4,5}.txt --cols=80 --show-all-spaces
-check_gold gold-45-h.txt            tests/input-{4,5}.txt --cols=80 --highlight
-check_gold gold-45-nb.txt           tests/input-{4,5}.txt --cols=80 --no-bold
-check_gold gold-45-sas-h.txt        tests/input-{4,5}.txt --cols=80 --show-all-spaces --highlight
-check_gold gold-45-sas-h-nb.txt     tests/input-{4,5}.txt --cols=80 --show-all-spaces --highlight --no-bold
-check_gold gold-45-h-nb.txt         tests/input-{4,5}.txt --cols=80 --highlight --no-bold
-check_gold gold-45-ln.txt           tests/input-{4,5}.txt --cols=80 --line-numbers
-check_gold gold-45-ln-color.txt     tests/input-{4,5}.txt --cols=80 --line-numbers --color-map='line-numbers:cyan'
-check_gold gold-45-nh.txt           tests/input-{4,5}.txt --cols=80 --no-headers
-check_gold gold-45-h3.txt           tests/input-{4,5}.txt --cols=80 --head=3
-check_gold gold-45-l.txt            tests/input-{4,5}.txt --cols=80 -L left
-check_gold gold-45-lr.txt           tests/input-{4,5}.txt --cols=80 -L left -L right
-check_gold gold-45-lbrb.txt         tests/input-{4,5}.txt --cols=80 -L "L {basename}" -L "R {basename}"
-check_gold gold-45-pipe.txt         tests/input-4.txt <(cat tests/input-5.txt) --cols=80 --no-headers
-check_gold gold-4dn.txt             tests/input-4.txt /dev/null --cols=80 -L left -L right
-check_gold gold-dn5.txt             /dev/null tests/input-5.txt --cols=80 -L left -L right
-check_gold gold-67.txt              tests/input-{6,7}.txt --cols=80
-check_gold gold-67-wf.txt           tests/input-{6,7}.txt --cols=80 --whole-file
-check_gold gold-67-ln.txt           tests/input-{6,7}.txt --cols=80 --line-numbers
-check_gold gold-67-u3.txt           tests/input-{6,7}.txt --cols=80 -U 3
-check_gold gold-tabs-default.txt    tests/input-{8,9}.txt --cols=80
-check_gold gold-tabs-4.txt          tests/input-{8,9}.txt --cols=80 --tabsize=4
-check_gold gold-file-not-found.txt  tests/input-4.txt nonexistent_file
-check_gold gold-strip-cr-off.txt    tests/input-4.txt tests/input-4-cr.txt --cols=80
-check_gold gold-strip-cr-on.txt     tests/input-4.txt tests/input-4-cr.txt --cols=80 --strip-trailing-cr
-check_gold gold-no-cr-indent        tests/input-4-cr.txt tests/input-4-partial-cr.txt --cols=80
-check_gold gold-hide-cr-if-dos      tests/input-4-cr.txt tests/input-5-cr.txt --cols=80
-check_gold gold-12-subcolors.txt    tests/input-{1,2}.txt --cols=80 --color-map='change:magenta,description:cyan_bold'
-check_gold gold-subcolors-bad-color tests/input-{1,2}.txt --cols=80 --color-map='change:mageta,description:cyan_bold'
-check_gold gold-subcolors-bad-cat tests/input-{1,2}.txt --cols=80 --color-map='chnge:magenta,description:cyan_bold'
-check_gold gold-subcolors-bad-fmt tests/input-{1,2}.txt --cols=80 --color-map='change:magenta:gold,description:cyan_bold'
-check_gold gold-identical-on.txt tests/input-{1,1}.txt -s
-check_gold gold-bad-encoding.txt tests/input-{1,2}.txt --encoding=nonexistend_encoding
+check_gold 1 gold-recursive.txt       --recursive tests/{a,b} --cols=80
+check_gold 1 gold-exclude.txt         --exclude-lines '^#|  pad' tests/input-4-cr.txt tests/input-4-partial-cr.txt --cols=80
+check_gold 0 gold-dir.txt             tests/{a,b} --cols=80
+check_gold 1 gold-12.txt              tests/input-{1,2}.txt --cols=80
+check_gold 1 gold-12-t.txt            tests/input-{1,2}.txt --cols=80 --truncate
+check_gold 0 gold-3.txt               tests/input-{3,3}.txt
+check_gold 1 gold-45.txt              tests/input-{4,5}.txt --cols=80
+check_gold 1 gold-45-95.txt           tests/input-{4,5}.txt --cols=95
+check_gold 1 gold-45-sas.txt          tests/input-{4,5}.txt --cols=80 --show-all-spaces
+check_gold 1 gold-45-h.txt            tests/input-{4,5}.txt --cols=80 --highlight
+check_gold 1 gold-45-nb.txt           tests/input-{4,5}.txt --cols=80 --no-bold
+check_gold 1 gold-45-sas-h.txt        tests/input-{4,5}.txt --cols=80 --show-all-spaces --highlight
+check_gold 1 gold-45-sas-h-nb.txt     tests/input-{4,5}.txt --cols=80 --show-all-spaces --highlight --no-bold
+check_gold 1 gold-45-h-nb.txt         tests/input-{4,5}.txt --cols=80 --highlight --no-bold
+check_gold 1 gold-45-ln.txt           tests/input-{4,5}.txt --cols=80 --line-numbers
+check_gold 1 gold-45-ln-color.txt     tests/input-{4,5}.txt --cols=80 --line-numbers --color-map='line-numbers:cyan'
+check_gold 1 gold-45-nh.txt           tests/input-{4,5}.txt --cols=80 --no-headers
+check_gold 1 gold-45-h3.txt           tests/input-{4,5}.txt --cols=80 --head=3
+check_gold 2 gold-45-l.txt            tests/input-{4,5}.txt --cols=80 -L left
+check_gold 1 gold-45-lr.txt           tests/input-{4,5}.txt --cols=80 -L left -L right
+check_gold 1 gold-45-lbrb.txt         tests/input-{4,5}.txt --cols=80 -L "L {basename}" -L "R {basename}"
+check_gold 1 gold-45-pipe.txt         tests/input-4.txt <(cat tests/input-5.txt) --cols=80 --no-headers
+check_gold 1 gold-4dn.txt             tests/input-4.txt /dev/null --cols=80 -L left -L right
+check_gold 1 gold-dn5.txt             /dev/null tests/input-5.txt --cols=80 -L left -L right
+check_gold 1 gold-67.txt              tests/input-{6,7}.txt --cols=80
+check_gold 1 gold-67-wf.txt           tests/input-{6,7}.txt --cols=80 --whole-file
+check_gold 1 gold-67-ln.txt           tests/input-{6,7}.txt --cols=80 --line-numbers
+check_gold 1 gold-67-u3.txt           tests/input-{6,7}.txt --cols=80 -U 3
+check_gold 1 gold-tabs-default.txt    tests/input-{8,9}.txt --cols=80
+check_gold 1 gold-tabs-4.txt          tests/input-{8,9}.txt --cols=80 --tabsize=4
+check_gold 2 gold-file-not-found.txt  tests/input-4.txt nonexistent_file
+check_gold 1 gold-strip-cr-off.txt    tests/input-4.txt tests/input-4-cr.txt --cols=80
+check_gold 1 gold-strip-cr-on.txt     tests/input-4.txt tests/input-4-cr.txt --cols=80 --strip-trailing-cr
+check_gold 1 gold-no-cr-indent        tests/input-4-cr.txt tests/input-4-partial-cr.txt --cols=80
+check_gold 1 gold-hide-cr-if-dos      tests/input-4-cr.txt tests/input-5-cr.txt --cols=80
+check_gold 1 gold-12-subcolors.txt    tests/input-{1,2}.txt --cols=80 --color-map='change:magenta,description:cyan_bold'
+check_gold 2 gold-subcolors-bad-color tests/input-{1,2}.txt --cols=80 --color-map='change:mageta,description:cyan_bold'
+check_gold 2 gold-subcolors-bad-cat tests/input-{1,2}.txt --cols=80 --color-map='chnge:magenta,description:cyan_bold'
+check_gold 2 gold-subcolors-bad-fmt tests/input-{1,2}.txt --cols=80 --color-map='change:magenta:gold,description:cyan_bold'
+check_gold 0 gold-identical-on.txt tests/input-{1,1}.txt -s
+check_gold 2 gold-bad-encoding.txt tests/input-{1,2}.txt --encoding=nonexistend_encoding
 
 if git show 4e86205629 &> /dev/null; then
   # We're in the repo, so test git.


### PR DESCRIPTION
This pull request adds code to mimic the behavior of grep.  It will return 1 to the invoking shell if differences between the  icdiff'ed files have been detected.  It will return 2, if an issue with the command line has been detected.