### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,9 @@ setup(
     name="icdiff",
     version=__version__,
     url="http://www.jefftk.com/icdiff",
+    project_urls={
+        "Source": "https://github.com/jeffkaufman/icdiff",
+    },
     author="Jeff Kaufman",
     author_email="jeff@jefftk.com",
     description="improved colored diff",


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)