### PR TITLE
Add license classifier to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,9 @@ setup(
     project_urls={
         "Source": "https://github.com/jeffkaufman/icdiff",
     },
+    classifiers=[
+        "License :: OSI Approved :: Python Software Foundation License"
+    ],
     author="Jeff Kaufman",
     author_email="jeff@jefftk.com",
     description="improved colored diff",


### PR DESCRIPTION
Due to the lack of metadata in the package, license checkers like `pylic` are reporting that this package is unsafe.
This PR aims to fix that.

- Add license classifier to setup.py
