### PR TITLE
test: Don't fail on 'rm' when file doesn't exist

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -160,7 +160,7 @@ check_gold 0 gold-recursive-with-exclude.txt --recursive -x c tests/{a,b} --cols
 check_gold 1 gold-recursive-with-exclude2.txt --recursive -x 'excl*' tests/test-with-exclude/{a,b} --cols=80
 check_gold 0 gold-exit-process-sub tests/input-1.txt <(cat tests/input-1.txt) --cols=80
 
-rm tests/permissions-{a,b}
+rm -f tests/permissions-{a,b}
 touch tests/permissions-{a,b}
 check_gold 0 gold-permissions-same.txt tests/permissions-{a,b} -P --cols=80
 
@@ -173,7 +173,7 @@ check_gold 1 gold-permissions-diff-text.txt tests/permissions-{a,b} -P --cols=80
 
 echo -e "\04" >> tests/permissions-b
 check_gold 1 gold-permissions-diff-binary.txt tests/permissions-{a,b} -P --cols=80
-rm tests/permissions-{a,b}
+rm -f tests/permissions-{a,b}
 
 if git show 4e86205629 &> /dev/null; then
   # We're in the repo, so test git.
@@ -209,7 +209,7 @@ function ensure_installed() {
 
 ensure_installed "black"
 echo 'Running black formatter...'
-if ! black icdiff --line-length 79 --check; then
+if ! black icdiff --quiet --line-length 79 --check; then
   echo ""
   echo 'Consider running `black icdiff --line-length 79`'
   fail


### PR DESCRIPTION
Also, call "black" with --quiet so it won't emit non-error messages to stderr.

Thanks for pushing the fix for the file descriptor numbering problem https://github.com/jeffkaufman/icdiff/commit/1c2a042a3c2c1041a0ec011c9f33c3ba77c06de0

This is a simple change in the test script to prevent it to fail when those files don't exist. It is also causing problems with the Debian package during tests. The package has a patch to workaround this problem, but it would be great if we could have these changes upstream so we can drop the patch and make maintenance easier:

https://salsa.debian.org/debian/icdiff/-/blob/master/debian/patches/no-message-on-rm-nonexistant.patch

Thanks!