### PR TITLE
Correct codecs.open() deprecation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2.0.8
+  Correct deprecation warning #225
+
 2.0.7
 	Add --show-no-spaces #173
 

--- a/icdiff
+++ b/icdiff
@@ -25,7 +25,7 @@ import unicodedata
 import codecs
 import fnmatch
 
-__version__ = "2.0.7"
+__version__ = "2.0.8"
 
 # Exit code constants
 EXIT_CODE_SUCCESS = 0
@@ -877,7 +877,7 @@ def diff(options, a, b):
 
 def read_file(fname, options):
     try:
-        with codecs.open(fname, encoding=options.encoding, mode="rb") as inf:
+        with open(fname, encoding=options.encoding) as inf:
             return inf.readlines()
     except UnicodeDecodeError as e:
         codec_print(


### PR DESCRIPTION
This pull request updates the project to version 2.0.8 and addresses a deprecation warning related to file reading. The most significant change is replacing the deprecated use of `codecs.open` with the built-in `open` function for reading files with encoding, which corrects a deprecation warning.

Version bump and changelog:

* Updated the version number to `2.0.8` in both the `ChangeLog` and the `__version__` variable in `icdiff`. [[1]](diffhunk://#diff-91c5b46dc84a94604a4e4d0caed9bf85590a2eddbb12d2e8dc80badf324a9dfbR1-R3) [[2]](diffhunk://#diff-fb3c35ce45cddaa2d0f3eb3d29298e4972d41b830a931f537e51ee31e55bd2dbL28-R28)

Deprecation warning fix:

* Replaced `codecs.open` with the built-in `open` function (with encoding) in the `read_file` function to resolve a deprecation warning.

Fixes #225