### PR TITLE
fix cols default on macOS

### DIFF
--- a/icdiff
+++ b/icdiff
@@ -24,6 +24,7 @@ import filecmp
 import unicodedata
 import codecs
 import fnmatch
+import shutil
 
 __version__ = "2.0.8"
 
@@ -734,44 +735,6 @@ def create_option_parser():
     return parser
 
 
-def set_cols_option(options):
-    if os.name == "nt":
-        try:
-            import struct
-            from ctypes import windll, create_string_buffer
-
-            fh = windll.kernel32.GetStdHandle(-12)  # stderr is -12
-            csbi = create_string_buffer(22)
-            windll.kernel32.GetConsoleScreenBufferInfo(fh, csbi)
-            res = struct.unpack("hhhhHhhhhhh", csbi.raw)
-            options.cols = res[7] - res[5] + 1  # right - left + 1
-            return
-
-        except Exception:
-            pass
-
-    else:
-
-        def ioctl_GWINSZ(fd):
-            try:
-                import fcntl
-                import termios
-                import struct
-
-                cr = struct.unpack(
-                    "hh", fcntl.ioctl(fd, termios.TIOCGWINSZ, "1234")
-                )
-            except Exception:
-                return None
-            return cr
-
-        cr = ioctl_GWINSZ(0) or ioctl_GWINSZ(1) or ioctl_GWINSZ(2)
-        if cr and cr[1] > 0:
-            options.cols = cr[1]
-            return
-    options.cols = 80
-
-
 def validate_has_two_arguments(parser, args):
     if len(args) != 2:
         parser.print_help()
@@ -784,7 +747,7 @@ def start():
     options, args = parser.parse_args()
     validate_has_two_arguments(parser, args)
     if not options.cols:
-        set_cols_option(options)
+        options.cols = shutil.get_terminal_size().columns
     try:
         diffs_found = diff(options, *args)
     except KeyboardInterrupt:


### PR DESCRIPTION
On macOS, you can't just pass the string 1234 to this ioctl, it needs to be 8 bytes:
```
>>> import fcntl, termios
>>> fcntl.ioctl(0, termios.TIOCGWINSZ, "1234")
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    fcntl.ioctl(0, termios.TIOCGWINSZ, "1234")
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SystemError: buffer overflow
```

But shutil [provides](https://docs.python.org/3/library/shutil.html#shutil.get_terminal_size) a cross-platform way to get the terminal width, which we should just use.