### PR TITLE
fix buffer overflow when getting column count

### DIFF
--- a/icdiff
+++ b/icdiff
@@ -759,7 +759,7 @@ def set_cols_option(options):
                 import struct
 
                 cr = struct.unpack(
-                    "hh", fcntl.ioctl(fd, termios.TIOCGWINSZ, "1234")
+                    "hhhh", fcntl.ioctl(fd, termios.TIOCGWINSZ, "12345678")
                 )
             except Exception:
                 return None


### PR DESCRIPTION
The manpage `TIOCGWINSZ(2const)` shows that the returned struct contains 4 shorts, not 2; the ioctl call previously threw a buffer overflow exception on my system, resulting in the column count incorrectly defaulting to 80.

From the manpage:
```c
struct winsize {
    unsigned short ws_row;
    unsigned short ws_col;
    unsigned short ws_xpixel;  /* unused */
    unsigned short ws_ypixel;  /* unused */
};
```