### PR TITLE
Fix TIOCGWINSZ call for autodetecting screen width

### DIFF
--- a/icdiff
+++ b/icdiff
@@ -759,8 +759,8 @@ def set_cols_option(options):
                 import struct
 
                 cr = struct.unpack(
-                    "hh", fcntl.ioctl(fd, termios.TIOCGWINSZ, "1234")
-                )
+                    "hhhh", fcntl.ioctl(0, termios.TIOCGWINSZ, b"12345678")
+                )[0:2]
             except Exception:
                 return None
             return cr


### PR DESCRIPTION
Due to changes in fcntl.ioctl() in python 3.14, icdiff's screen width autodetection broke.

The problem, as described in [PATCH: knotty: fix TIOCGWINSZ call for Python 3.14 and later](https://lists.openembedded.org/g/bitbake-devel/message/18351):

```
Python 3.14 enforces stricter type and size checking for fcntl.ioctl()
buffer arguments. The previous code passed a short 4-byte string ('1234')
to TIOCGWINSZ, which worked by accident in older Python versions but causes
a SystemError ("buffer overflow") in 3.14.

TIOCGWINSZ expects an 8-byte (4x 16-bit) buffer corresponding to
(rows, cols, xpix, ypix). Use an 8-byte bytes literal instead and unpack
the first two values.
```

knotty patch tested this as far back as python 3.11 and it still works, so likely this works for all past versions with equivalent fcntl.ioctl() method.

This PR applies similar change to icdiff.